### PR TITLE
Temove reference to npm in package.json for 'test' script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "./node_modules/eslint/bin/eslint.js --fix ./lib",
-    "test": "npm run mocha"
+    "test": "mocha"
   },
   "files": [
     "lib/"


### PR DESCRIPTION
Referencing package manager is not required for `scripts`, furthermore it restrict usage with `npm` only (doesn't work with `yarn` for example).
>[...]
>In addition to the shell’s pre-existing PATH, npm run adds node_modules/.bin to the PATH provided to scripts. Any binaries provided by locally-installed dependencies can be used without the node_modules/.bin prefix. For example, if there is a devDependency on tap in your package, you should write:
> `"scripts": {"test": "tap test/\*.js"}`
>[...]
> https://docs.npmjs.com/cli/run-script#description