### PR TITLE
[BUG][Analytics] Video and Livestream analytics get and search methods are crashing

### DIFF
--- a/lib/Api/analyticsLive.js
+++ b/lib/Api/analyticsLive.js
@@ -85,8 +85,8 @@ const AnalyticsLive = function AnalyticsLive(browser) {
 AnalyticsLive.prototype.castAll = function castAll(collection) {
   return arrayMap((data) => {
     const analyticLive = new AnalyticLive();
-    analyticLive.liveStreamId = data.live.liveStreamId;
-    analyticLive.liveName = data.live.name;
+    analyticLive.liveStreamId = data.live ? data.live.liveStreamId : null;
+    analyticLive.liveName = data.live ? data.live.name : null;
     analyticLive.period = data.period;
     // Build Analytic Data
     Object.keys(data.data).forEach((key) => {
@@ -138,8 +138,8 @@ AnalyticsLive.prototype.cast = function cast(data) {
   }
 
   const analyticLive = new AnalyticLive();
-  analyticLive.liveStreamId = data.live.liveStreamId;
-  analyticLive.liveName = data.live.name;
+  analyticLive.liveStreamId = data.live ? data.live.liveStreamId : null;
+  analyticLive.liveName = data.live ? data.live.name : null;
   analyticLive.period = data.period;
   // Build Analytic Data
   Object.keys(data.data).forEach((key) => {

--- a/lib/Api/analyticsVideo.js
+++ b/lib/Api/analyticsVideo.js
@@ -85,8 +85,8 @@ const AnalyticsVideo = function AnalyticsVideo(browser) {
 AnalyticsVideo.prototype.castAll = function castAll(collection) {
   return arrayMap((data) => {
     const analyticVideo = new AnalyticVideo();
-    analyticVideo.videoId = data.video.videoId;
-    analyticVideo.videoTitle = data.video.title;
+    analyticVideo.videoId = data.video ? data.video.videoId : null;
+    analyticVideo.videoTitle = data.video ? data.video.title : null;
     analyticVideo.period = data.period;
     // Build Analytic Data
     Object.keys(data.data).forEach((key) => {
@@ -136,8 +136,8 @@ AnalyticsVideo.prototype.cast = function cast(data) {
     return null;
   }
   const analyticVideo = new AnalyticVideo();
-  analyticVideo.videoId = data.video.videoId;
-  analyticVideo.videoTitle = data.video.title;
+  analyticVideo.videoId = data.video ? data.video.videoId : null;
+  analyticVideo.videoTitle = data.video ? data.video.title : null;
   analyticVideo.period = data.period;
   // Build Analytic Data
   Object.keys(data.data).forEach((key) => {


### PR DESCRIPTION
At the moment both `livestream` and `video` analytics methods are crashing.
See for yourself, either the `data.live` or `data.video` are never set, `cast` methods are only called with the sessions data. 
```
TypeError: Cannot read property 'videoId' of undefined
    at AnalyticsVideo.cast (node_modules/@api.video/nodejs-sdk/lib/Api/analyticsVideo.js:139:38)
```

Same goes for `data.period` but this doesn't crash.

This is just a quickfix really. But at least the analytics method works for now. 

Didn't want to propose smthing that would change methods signatures or remove features, I prefer to let you think of the best way to fix this.