### PR TITLE
fix: Clone `parameters` instead of passing it by reference

### DIFF
--- a/lib/Api/analyticsLive.js
+++ b/lib/Api/analyticsLive.js
@@ -29,7 +29,7 @@ const AnalyticsLive = function AnalyticsLive(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = { ...parameters };
+    const params = Object.assign({}, parameters);
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/analyticsLive.js
+++ b/lib/Api/analyticsLive.js
@@ -29,7 +29,7 @@ const AnalyticsLive = function AnalyticsLive(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = parameters;
+    const params = { ...parameters };
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/analyticsSessionEvent.js
+++ b/lib/Api/analyticsSessionEvent.js
@@ -8,7 +8,7 @@ const AnalyticsSessionEvent = function AnalyticsSessionEvent(browser) {
 
   this.get = async function get(sessionId, parameters = {}) {
     const that = this;
-    const params = parameters;
+    const params = { ...parameters };
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/analyticsSessionEvent.js
+++ b/lib/Api/analyticsSessionEvent.js
@@ -8,7 +8,7 @@ const AnalyticsSessionEvent = function AnalyticsSessionEvent(browser) {
 
   this.get = async function get(sessionId, parameters = {}) {
     const that = this;
-    const params = { ...parameters };
+    const params = Object.assign({}, parameters);
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;
@@ -44,7 +44,6 @@ const AnalyticsSessionEvent = function AnalyticsSessionEvent(browser) {
       ({ pagination } = results);
       pagination.currentPage += 1;
       params.currentPage = pagination.currentPage;
-
     } while (pagination.pagesTotal > pagination.currentPage);
 
     return new Promise((async (resolve, reject) => {

--- a/lib/Api/analyticsVideo.js
+++ b/lib/Api/analyticsVideo.js
@@ -29,7 +29,7 @@ const AnalyticsVideo = function AnalyticsVideo(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = { ...parameters };
+    const params = Object.assign({}, parameters);
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/analyticsVideo.js
+++ b/lib/Api/analyticsVideo.js
@@ -29,7 +29,7 @@ const AnalyticsVideo = function AnalyticsVideo(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = parameters;
+    const params = { ...parameters };
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/lives.js
+++ b/lib/Api/lives.js
@@ -41,7 +41,7 @@ const Lives = function Lives(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = { ...parameters };
+    const params = Object.assign({}, parameters);
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/lives.js
+++ b/lib/Api/lives.js
@@ -41,7 +41,7 @@ const Lives = function Lives(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = parameters;
+    const params = { ...parameters };
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/players.js
+++ b/lib/Api/players.js
@@ -41,7 +41,7 @@ const Players = function Players(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = parameters;
+    const params = { ...parameters };
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/players.js
+++ b/lib/Api/players.js
@@ -41,7 +41,7 @@ const Players = function Players(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = { ...parameters };
+    const params = Object.assign({}, parameters);
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/videos.js
+++ b/lib/Api/videos.js
@@ -62,7 +62,7 @@ const Videos = function Videos(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = { ...parameters };
+    const params = Object.assign({}, parameters);
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;

--- a/lib/Api/videos.js
+++ b/lib/Api/videos.js
@@ -62,7 +62,7 @@ const Videos = function Videos(browser) {
 
   this.search = async function search(parameters = {}) {
     const that = this;
-    const params = parameters;
+    const params = { ...parameters };
     const currentPage = (typeof parameters.currentPage !== 'undefined')
       ? parameters.currentPage
       : 1;


### PR DESCRIPTION
The `parameters` object was used as if it was pristine in the `do while` loop :
```
if (typeof parameters.currentPage !== 'undefined') {
  break;
}
```
This condition is always true since `params.currentPage` is always assigned a value and `params` was just a reference of `parameters`.

Thus fetching many pages never worked.

> Let me know if you would prefer an `Object.assign` synthax instead of the *spread* operator (spread is available since node 8 anyway).

Also, would that be possible to speak to someone about the issues we are encountering with your libs ? There are other issues that we're about to fix but, still, this is quite an amount of work.