### PR TITLE
chore: Add missing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "lint": "./node_modules/eslint/bin/eslint.js --fix ./lib",
-    "test": "mocha"
+    "test": "mocha --require test/api/index.js"
   },
   "files": [
     "lib/"
@@ -33,7 +33,8 @@
     "eslint-config-airbnb": "^17.1.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-react": "^7.12.3",
-    "mocha": "^5.2.0",
+    "mocha": "^8.0.1",
+    "nock": "^13.0.2",
     "sinon": "^7.2.2"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "no-restricted-syntax": "off"
+  }
+}

--- a/test/analyticsLives.spec.js
+++ b/test/analyticsLives.spec.js
@@ -1,11 +1,20 @@
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const apiVideo = require('../lib');
+const AnalyticLive = require('../lib/Model/Analytic/analyticLive.js');
+const AnalyticData = require('../lib/Model/Analytic/analyticData.js');
+const { ITEMS_TOTAL } = require('./api');
+const sessionResponse = require('./api/session');
 
 describe('analyticsLive ressource', () => {
   describe('get without period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      await client.analyticsLive.get('lix1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.analyticsLive.get('lix1x1x1x1x1x1x1x1x1x');
+      client.analyticsLive.get('lix1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.analyticsLive.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/live-streams/lix1x1x1x1x1x1x1x1x1x?',
         method: 'GET',
@@ -13,11 +22,35 @@ describe('analyticsLive ressource', () => {
         json: true,
       });
     });
+
+    it('Return an analytic video object', async () => {
+      const liveStreamId = 'lix1x1x1x1x1x1x1x1x1x';
+      const analyticVideo = await client.analyticsLive.get(liveStreamId);
+      expect(analyticVideo).to.be.an('object');
+      expect(analyticVideo).to.have.keys(Object.keys(new AnalyticLive()));
+      expect(analyticVideo).to.have.property('videoId', liveStreamId);
+      expect(analyticVideo.data).to.be.an('array');
+      analyticVideo.data.forEach(
+        analyticData => expect(analyticData).to.have.keys(Object.keys(new AnalyticData())),
+      );
+    });
+
+    it('Return all analytic data', async () => {
+      const analyticVideo = await client.analyticsLive.get('lix1x1x1x1x1x1x1x1x1x');
+      expect(analyticVideo.data).to.be.an('array');
+      expect(analyticVideo.data).to.be.of.length(ITEMS_TOTAL);
+    });
   });
+
   describe('get with period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      await client.analyticsLive.get('lix1x1x1x1x1x1x1x1x1x', '2019-01');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.analyticsLive.get('lix1x1x1x1x1x1x1x1x1x', '2019-01');
+      client.analyticsLive.get('lix1x1x1x1x1x1x1x1x1x', '2019-01').catch(() => {});
       expect(client.analyticsLive.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/live-streams/lix1x1x1x1x1x1x1x1x1x?period=2019-01',
         method: 'GET',
@@ -25,16 +58,36 @@ describe('analyticsLive ressource', () => {
         json: true,
       });
     });
+
+    it('Return an analytic video object', async () => {
+      const period = '2019-01';
+      const liveStreamId = 'lix1x1x1x1x1x1x1x1x1x';
+      const analyticLive = await client.analyticsLive.get(liveStreamId, '2019-01');
+      expect(analyticLive).to.be.an('object');
+      expect(analyticLive).to.have.keys(Object.keys(new AnalyticLive()));
+      expect(analyticLive).to.have.property('videoId', liveStreamId);
+      expect(analyticLive).to.have.property('period', period);
+
+      expect(analyticLive.data).to.be.an('array');
+      analyticLive.data.forEach(
+        analyticData => expect(analyticData).to.have.keys(Object.keys(new AnalyticData())),
+      );
+    });
   });
 
-  describe('Search with parameters without period', () => {
+  describe('Search first page parameters without period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {
+      currentPage: 1,
+      pageSize: 25,
+    };
+
+    it('Does not throw', async () => {
+      await client.analyticsLive.search(parameters);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {
-        currentPage: 1,
-        pageSize: 25,
-      };
-      client.analyticsLive.search(parameters);
+      client.analyticsLive.search(parameters).catch(() => {});
       expect(client.analyticsLive.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/live-streams?currentPage=1&pageSize=25',
         method: 'GET',
@@ -45,14 +98,20 @@ describe('analyticsLive ressource', () => {
   });
 
   describe('Search with parameters with period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {
+      currentPage: 1,
+      pageSize: 25,
+      period: '2019-01',
+    };
+
+    it('Does not throw', async () => {
+      await client.analyticsLive
+        .search(parameters);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {
-        currentPage: 1,
-        pageSize: 25,
-        period: '2019-01',
-      };
-      client.analyticsLive.search(parameters);
+      client.analyticsLive.search(parameters).catch(() => {});
       expect(client.analyticsLive.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/live-streams?currentPage=1&pageSize=25&period=2019-01',
         method: 'GET',
@@ -63,10 +122,16 @@ describe('analyticsLive ressource', () => {
   });
 
   describe('Search without parameters without period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {};
+
+    it('Does not throw', async () => {
+      await client.analyticsLive
+        .search(parameters);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {};
-      client.analyticsLive.search(parameters);
+      client.analyticsLive.search(parameters).catch(() => {});
       expect(client.analyticsLive.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/live-streams?pageSize=100&currentPage=1',
         method: 'GET',
@@ -77,12 +142,18 @@ describe('analyticsLive ressource', () => {
   });
 
   describe('Search without parameters with period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {
+      period: '2019-01',
+    };
+
+    it('Does not throw', async () => {
+      await client.analyticsLive
+        .search(parameters);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {
-        period: '2019-01',
-      };
-      client.analyticsLive.search(parameters);
+      client.analyticsLive.search(parameters).catch(() => {});
       expect(client.analyticsLive.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/live-streams?period=2019-01&pageSize=100&currentPage=1',
         method: 'GET',
@@ -92,4 +163,17 @@ describe('analyticsLive ressource', () => {
     });
   });
 
+  describe('Casting a session', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      expect(client.analyticsLive.cast(sessionResponse)).to.not.throw();
+    });
+
+    it('Cast date fields to Date objects', () => {
+      const castedSession = client.analyticsLive.cast(sessionResponse);
+      expect(castedSession).to.have.property('loadedAt').that.is.an.instanceof(Date);
+      expect(castedSession).to.have.property('endedAt').that.is.an.instanceof(Date);
+    });
+  });
 });

--- a/test/analyticsSessionEvent.spec.js
+++ b/test/analyticsSessionEvent.spec.js
@@ -1,11 +1,17 @@
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const apiVideo = require('../lib');
+const { ITEMS_TOTAL } = require('./api');
 
 describe('AnalyticsSessionEvent ressource', () => {
   describe('get without parameters', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      await client.analyticsSessionEvent.get('psx1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.analyticsSessionEvent.get('psx1x1x1x1x1x1x1x1x1x');
+      client.analyticsSessionEvent.get('psx1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.analyticsSessionEvent.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/sessions/psx1x1x1x1x1x1x1x1x1x/events?pageSize=100&currentPage=1',
         method: 'GET',
@@ -15,20 +21,54 @@ describe('AnalyticsSessionEvent ressource', () => {
     });
   });
 
-  describe('GET with parameters', () => {
+  describe('get first page', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {
+      currentPage: 1,
+      pageSize: 25,
+    };
+
+    it('Does not throw', async () => {
+      await client.analyticsSessionEvent.get('psx1x1x1x1x1x1x1x1x1x', parameters);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {
-        currentPage: 1,
-        pageSize: 25,
-      };
-      client.analyticsSessionEvent.get('psx1x1x1x1x1x1x1x1x1x', parameters);
+      client.analyticsSessionEvent.get('psx1x1x1x1x1x1x1x1x1x', parameters).catch(() => {});
       expect(client.analyticsSessionEvent.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/sessions/psx1x1x1x1x1x1x1x1x1x/events?currentPage=1&pageSize=25',
         method: 'GET',
         headers: {},
         json: true,
       });
+    });
+
+    it('Retrieves only the first page', async () => {
+      const analyticSessionEvent = await client.analyticsSessionEvent.get('psx1x1x1x1x1x1x1x1x1x', parameters);
+      expect(analyticSessionEvent.events).to.have.lengthOf(parameters.pageSize);
+    });
+  });
+
+  describe('get without parameters', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      await client.analyticsSessionEvent
+        .get('psx1x1x1x1x1x1x1x1x1x');
+    });
+
+    it('Sends good request', () => {
+      client.analyticsSessionEvent.get('psx1x1x1x1x1x1x1x1x1x').catch(() => {});
+      expect(client.analyticsSessionEvent.browser.lastRequest).to.deep.equal({
+        url: 'https://ws.api.video/analytics/sessions/psx1x1x1x1x1x1x1x1x1x/events?pageSize=100&currentPage=1',
+        method: 'GET',
+        headers: {},
+        json: true,
+      });
+    });
+
+    it('Retrieves all pages', async () => {
+      const analyticSessionEvent = await client.analyticsSessionEvent.get('psx1x1x1x1x1x1x1x1x1x');
+      expect(analyticSessionEvent.events).to.have.lengthOf(ITEMS_TOTAL);
     });
   });
 });

--- a/test/analyticsVideos.spec.js
+++ b/test/analyticsVideos.spec.js
@@ -1,11 +1,20 @@
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const apiVideo = require('../lib');
+const AnalyticVideo = require('../lib/Model/Analytic/analyticVideo');
+const AnalyticData = require('../lib/Model/Analytic/analyticData');
+const sessionResponse = require('./api/session');
+const { ITEMS_TOTAL } = require('./api');
 
 describe('AnalyticsVideo ressource', () => {
   describe('get without period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      await client.analyticsVideo.get('vix1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.analyticsVideo.get('vix1x1x1x1x1x1x1x1x1x');
+      client.analyticsVideo.get('vix1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.analyticsVideo.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/videos/vix1x1x1x1x1x1x1x1x1x?',
         method: 'GET',
@@ -13,11 +22,32 @@ describe('AnalyticsVideo ressource', () => {
         json: true,
       });
     });
+
+    it('Return an analytic video object', async () => {
+      const analyticVideo = await client.analyticsVideo.get('vix1x1x1x1x1x1x1x1x1x');
+      expect(analyticVideo).to.be.an('object');
+      expect(analyticVideo).to.have.keys(Object.keys(new AnalyticVideo()));
+      expect(analyticVideo.data).to.be.an('array');
+      analyticVideo.data.forEach(
+        analyticData => expect(analyticData).to.have.keys(Object.keys(new AnalyticData())),
+      );
+    });
+
+    it('Return all analytic data', async () => {
+      const analyticVideo = await client.analyticsVideo.get('vix1x1x1x1x1x1x1x1x1x');
+      expect(analyticVideo.data).to.be.an('array');
+      expect(analyticVideo.data).to.be.of.length(ITEMS_TOTAL);
+    });
   });
+
   describe('get with period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    it('Does not throw', async () => {
+      await client.analyticsVideo.get('vix1x1x1x1x1x1x1x1x1x', '2019-01');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.analyticsVideo.get('vix1x1x1x1x1x1x1x1x1x', '2019-01');
+      client.analyticsVideo.get('vix1x1x1x1x1x1x1x1x1x', '2019-01').catch(() => {});
       expect(client.analyticsVideo.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/videos/vix1x1x1x1x1x1x1x1x1x?period=2019-01',
         method: 'GET',
@@ -25,16 +55,37 @@ describe('AnalyticsVideo ressource', () => {
         json: true,
       });
     });
+
+    it('Return an analytic video object', async () => {
+      const period = '2019-01';
+      const videoId = 'vix1x1x1x1x1x1x1x1x1x';
+      const analyticVideo = await client.analyticsVideo.get(videoId, '2019-01');
+      expect(analyticVideo).to.be.an('object');
+      expect(analyticVideo).to.have.keys(Object.keys(new AnalyticVideo()));
+      expect(analyticVideo).to.have.property('videoId', videoId);
+      expect(analyticVideo).to.have.property('period', period);
+
+      expect(analyticVideo.data).to.be.an('array');
+      analyticVideo.data.forEach(
+        analyticData => expect(analyticData).to.have.keys(Object.keys(new AnalyticData())),
+      );
+    });
   });
 
   describe('Search with parameters without period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {
+      currentPage: 1,
+      pageSize: 25,
+    };
+
+    it('Does not throw', async () => {
+      await client.analyticsVideo
+        .search(parameters);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {
-        currentPage: 1,
-        pageSize: 25,
-      };
-      client.analyticsVideo.search(parameters);
+      client.analyticsVideo.search(parameters).catch(() => {});
       expect(client.analyticsVideo.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/videos?currentPage=1&pageSize=25',
         method: 'GET',
@@ -42,17 +93,31 @@ describe('AnalyticsVideo ressource', () => {
         json: true,
       });
     });
+
+    it('Return an array of analytic video object', async () => {
+      const analyticsVideos = await client.analyticsVideo.search(parameters);
+      expect(analyticsVideos).to.be.an('array');
+      analyticsVideos.data.forEach(
+        analyticVideo => expect(analyticVideo).to.have.keys(Object.keys(new AnalyticVideo())),
+      );
+    });
   });
 
   describe('Search with parameters with period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {
+      currentPage: 1,
+      pageSize: 25,
+      period: '2019-01',
+    };
+
+    it('Does not throw', async () => {
+      await client.analyticsVideo
+        .search(parameters);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {
-        currentPage: 1,
-        pageSize: 25,
-        period: '2019-01',
-      };
-      client.analyticsVideo.search(parameters);
+      client.analyticsVideo.search(parameters).catch(() => {});
       expect(client.analyticsVideo.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/videos?currentPage=1&pageSize=25&period=2019-01',
         method: 'GET',
@@ -63,10 +128,16 @@ describe('AnalyticsVideo ressource', () => {
   });
 
   describe('Search without parameters without period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {};
+
+    it('Does not throw', async () => {
+      await client.analyticsVideo
+        .search(parameters);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {};
-      client.analyticsVideo.search(parameters);
+      client.analyticsVideo.search(parameters).catch(() => {});
       expect(client.analyticsVideo.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/videos?pageSize=100&currentPage=1',
         method: 'GET',
@@ -77,18 +148,37 @@ describe('AnalyticsVideo ressource', () => {
   });
 
   describe('Search without parameters with period', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {
+      period: '2019-01',
+    };
+
+    it('Does not throw', async () => {
+      await client.analyticsVideo.search(parameters);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {
-        period: '2019-01',
-      };
-      client.analyticsVideo.search(parameters);
+      client.analyticsVideo.search(parameters).catch(() => {});
       expect(client.analyticsVideo.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/analytics/videos?period=2019-01&pageSize=100&currentPage=1',
         method: 'GET',
         headers: {},
         json: true,
       });
+    });
+  });
+
+  describe('Casting a session', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      expect(client.analyticsVideo.cast(sessionResponse)).to.not.throw();
+    });
+
+    it('Cast date fields to Date objects', () => {
+      const castedSession = client.analyticsVideo.cast(sessionResponse);
+      expect(castedSession).to.have.property('loadedAt').that.is.an.instanceof(Date);
+      expect(castedSession).to.have.property('endedAt').that.is.an.instanceof(Date);
     });
   });
 });

--- a/test/api/caption.js
+++ b/test/api/caption.js
@@ -1,0 +1,7 @@
+const caption = {
+  language: 'fr',
+  src: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/captions/fr.vtt',
+  uri: '/videos/vi3N6cDinStg3oBbN79GklWS/captions/fr',
+};
+
+module.exports = caption;

--- a/test/api/chapter.js
+++ b/test/api/chapter.js
@@ -1,0 +1,7 @@
+const chapter = {
+  language: 'fr',
+  src: 'https://cdn.api.video/vod/vi3N6cDinStg3oBbN79GklWS/chapters/fr.vtt',
+  uri: '/videos/vi3N6cDinStg3oBbN79GklWS/chapters/fr',
+};
+
+module.exports = chapter;

--- a/test/api/createCollection.js
+++ b/test/api/createCollection.js
@@ -1,0 +1,34 @@
+const createCollection = item => ({
+  currentPage = 1,
+  pageSize = 100,
+  itemsTotal,
+}) => {
+  const pagesTotal = Math.ceil(itemsTotal / pageSize);
+  const currentPageItems = currentPage === pagesTotal ? itemsTotal % pageSize : pageSize;
+  return {
+    data: Array.from(Array(currentPageItems)).fill(Object.assign(item, { videoId: Math.random() })),
+    pagination: {
+      currentPage,
+      currentPageItems,
+      itemsTotal,
+      links: [
+        {
+          rel: 'self',
+          uri: `https://ws.api.video/videos?currentPage=${currentPage}`,
+        },
+        {
+          rel: 'first',
+          uri: 'https://ws.api.video/videos?currentPage=1',
+        },
+        {
+          rel: 'last',
+          uri: `https://ws.api.video/videos?currentPage=${pagesTotal}`,
+        },
+      ],
+      pageSize,
+      pagesTotal,
+    },
+  };
+};
+
+module.exports = createCollection;

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -1,0 +1,176 @@
+const nock = require('nock');
+const url = require('url');
+const createCollection = require('./createCollection');
+const video = require('./video');
+const liveStream = require('./liveStream');
+const session = require('./session');
+const sessionEvent = require('./sessionEvent');
+const chapter = require('./chapter');
+const caption = require('./caption');
+const player = require('./player');
+
+const BASE = 'https://ws.api.video';
+const ITEMS_TOTAL = 293;
+
+const fromEntries = (entries) => {
+  const params = { pagesTotal: 3 };
+  for (const [key, value] of entries) {
+    params[key] = Number(value);
+  }
+
+  return params;
+};
+
+const getRequestParameters = (req) => {
+  const { searchParams } = new url.URL(req.path, BASE);
+  return fromEntries(searchParams.entries());
+};
+
+const createCollectionReply = (item, itemsTotal = ITEMS_TOTAL) => function () {
+  return createCollection(item)(Object.assign(
+    getRequestParameters(this.req),
+    { itemsTotal },
+  ));
+};
+
+exports.mochaHooks = {
+  beforeEach(done) {
+    nock(BASE)
+      .persist()
+      // auth
+      .post('/auth/api-key', {
+        apiKey: 'test',
+      })
+      .reply(200, {
+        token_type: '',
+        access_token: '',
+        refresh_token: '',
+      })
+      // tokens
+      .post('/tokens')
+      .reply(201)
+
+      // videos
+      .get('/videos')
+      .query(true)
+      .reply(200, createCollectionReply(video))
+      .post('/videos')
+      .query(true)
+      .reply(201)
+      .get('/videos/vix1x1x1x1x1x1x1x1x1x')
+      .query(true)
+      .reply(200, video)
+      .patch('/videos/vix1x1x1x1x1x1x1x1x1x')
+      .query(true)
+      .reply(200)
+      .delete('/videos/vix1x1x1x1x1x1x1x1x1x')
+      .reply(200)
+
+      // video thumbnail
+      .post('/videos/vix1x1x1x1x1x1x1x1x1x/thumbnail')
+      .reply(201)
+      .patch('/videos/vix1x1x1x1x1x1x1x1x1x/thumbnail')
+      .reply(200)
+
+      // video status
+      .get('/videos/vix1x1x1x1x1x1x1x1x1x/status')
+      .reply(201)
+
+      // video source
+      .post('/videos/vix1x1x1x1x1x1x1x1x1x/source')
+      .reply(201)
+
+      // videos chapters
+      .get('/videos/vix1x1x1x1x1x1x1x1x1x/chapters')
+      .reply(200, createCollectionReply(chapter))
+      .get('/videos/vix1x1x1x1x1x1x1x1x1x/chapters/en')
+      .reply(200, createCollectionReply(chapter))
+      .post('/videos/vix1x1x1x1x1x1x1x1x1x/chapters/en')
+      .reply(201, chapter)
+      .delete('/videos/vix1x1x1x1x1x1x1x1x1x/chapters/en')
+      .reply(200)
+      .patch('/videos/vix1x1x1x1x1x1x1x1x1x/chapters/en')
+      .reply(200)
+
+      // videos captions
+      .get('/videos/vix1x1x1x1x1x1x1x1x1x/captions')
+      .reply(200, createCollectionReply(caption))
+      .get('/videos/vix1x1x1x1x1x1x1x1x1x/captions/en')
+      .reply(200, createCollectionReply(caption))
+      .post('/videos/vix1x1x1x1x1x1x1x1x1x/captions/en')
+      .reply(201, caption)
+      .delete('/videos/vix1x1x1x1x1x1x1x1x1x/captions/en')
+      .reply(200)
+      .patch('/videos/vix1x1x1x1x1x1x1x1x1x/captions/en')
+      .reply(200)
+
+      // videos analytics
+      .get('/analytics/videos/vix1x1x1x1x1x1x1x1x1x')
+      .query(true)
+      .reply(200, createCollectionReply(session))
+      .get('/analytics/videos')
+      .query(true)
+      .reply(200, createCollectionReply(session))
+
+      // sessions
+      .get('/analytics/sessions/psx1x1x1x1x1x1x1x1x1x/events')
+      .query(true)
+      .reply(200, createCollectionReply(sessionEvent))
+
+      // live-streams
+      .get('/live-streams')
+      .query(true)
+      .reply(200, createCollectionReply(liveStream))
+
+      .post('/live-streams')
+      .query(true)
+      .reply(201)
+      .get('/live-streams/lix1x1x1x1x1x1x1x1x1x')
+      .query(true)
+      .reply(200, liveStream)
+      .patch('/live-streams/lix1x1x1x1x1x1x1x1x1x')
+      .query(true)
+      .reply(200)
+      .delete('/live-streams/lix1x1x1x1x1x1x1x1x1x')
+      .query(true)
+      .reply(200)
+      .post('/live-streams/lix1x1x1x1x1x1x1x1x1x/thumbnail')
+      .query(true)
+      .reply(201)
+      .patch('/live-streams/lix1x1x1x1x1x1x1x1x1x/thumbnail')
+      .query(true)
+      .reply(200)
+
+      // live-streams analytics
+      .get('/analytics/live-streams/lix1x1x1x1x1x1x1x1x1x')
+      .query(true)
+      .reply(200, createCollectionReply(session))
+      .get('/analytics/live-streams')
+      .query(true)
+      .reply(200, createCollectionReply(session))
+
+      // players
+      .get('/players')
+      .query(true)
+      .reply(200, createCollectionReply(player))
+      .post('/players')
+      .reply(200, player)
+
+      // player
+      .get('/players/plx1x1x1x1x1x1x1x1x1x')
+      .reply(200, player)
+      .patch('/players/plx1x1x1x1x1x1x1x1x1x')
+      .reply(200)
+      .delete('/players/plx1x1x1x1x1x1x1x1x1x')
+      .reply(200)
+
+      // player logo
+      .post('/players/plx1x1x1x1x1x1x1x1x1x/logo')
+      .reply(201)
+      .delete('/players/plx1x1x1x1x1x1x1x1x1x/logo')
+      .reply(200);
+    done();
+  },
+};
+
+exports.ITEMS_TOTAL = ITEMS_TOTAL;

--- a/test/api/liveStream.js
+++ b/test/api/liveStream.js
@@ -1,0 +1,16 @@
+const liveStream = {
+  liveStreamId: 'lix1x1x1x1x1x1x1x1x1x',
+  playerId: 'pl45KFKdlddgk654dspkze',
+  name: 'Maths live stream',
+  streamKey: '',
+  record: false,
+  broadcasting: true,
+  assets: {
+    iframe: '<iframe src=\'//embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfagz?token=831a9bd9-9f50-464c-a369-8e9d914371ae\' width=\'100%\' height=\'100%\' frameborder=\'0\' scrolling=\'no\' allowfullscreen=\'\'></iframe>',
+    player: 'https://embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfagz?token=831a9bd9-9f50-464c-a369-8e9d914371ae',
+    hls: 'https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8',
+    thumbnail: 'https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg',
+  },
+};
+
+module.exports = liveStream;

--- a/test/api/player.js
+++ b/test/api/player.js
@@ -1,0 +1,26 @@
+const player = {
+  backgroundBottom: 'rgba(94, 95, 89, 1)',
+  backgroundText: 'rgba(255, 255, 255, .95)',
+  backgroundTop: 'rgba(72, 4, 45, 1)',
+  createdAt: '2020-01-13T10:09:17+00:00',
+  enableApi: false,
+  enableControls: false,
+  forceAutoplay: false,
+  forceLoop: false,
+  hideTitle: false,
+  link: 'rgba(255, 0, 0, .95)',
+  linkActive: 'rgba(255, 0, 0, .75)',
+  linkHover: 'rgba(255, 255, 255, .75)',
+  playerId: 'plx1x1x1x1x1x1x1x1x1x',
+  shapeAspect: 'flat',
+  shapeBackgroundBottom: 'rgba(50, 50, 50, .8)',
+  shapeBackgroundTop: 'rgba(50, 50, 50, .7)',
+  shapeRadius: 3,
+  text: 'rgba(255, 255, 255, .95)',
+  trackBackground: 'rgba(0, 0, 0, 0)',
+  trackPlayed: 'rgba(255, 255, 255, .95)',
+  trackUnplayed: 'rgba(255, 255, 255, .1)',
+  updatedAt: '2020-01-13T11:12:14+00:00',
+};
+
+module.exports = player;

--- a/test/api/session.js
+++ b/test/api/session.js
@@ -1,0 +1,34 @@
+const session = {
+  client: {
+    name: 'Firefox',
+    type: 'browser',
+    version: '61.0',
+  },
+  device: {
+    model: 'unknown',
+    type: 'desktop',
+    vendor: 'unknown',
+  },
+  location: {
+    city: 'Paris',
+    country: 'France',
+  },
+  os: {
+    name: 'unknown',
+    shortname: 'unknown',
+    version: 'unknown',
+  },
+  referrer: {
+    medium: 'unknown',
+    searchTerm: 'unknown',
+    source: 'unknown',
+    url: 'unknown',
+  },
+  session: {
+    endedAt: '2018-09-11 14:47:22.186+00',
+    loadedAt: '2018-09-11 13:04:37.89+00',
+    sessionId: 'ps4zRWVOv2If2vzKJLMr3jQo',
+  },
+};
+
+module.expost = session;

--- a/test/api/sessionEvent.js
+++ b/test/api/sessionEvent.js
@@ -1,0 +1,7 @@
+const sessionEvent = {
+  type: 'player_session_vod.loaded',
+  emittedAt: '2019-01-01 03:11:35.973+01',
+  at: 0,
+};
+
+module.exports = sessionEvent;

--- a/test/api/video.js
+++ b/test/api/video.js
@@ -1,0 +1,38 @@
+const video = {
+  videoId: 'vix1x1x1x1x1x1x1x1x1x',
+  playerId: 'pl45KFKdlddgk654dspkze',
+  title: 'Maths video',
+  description: 'An amazing video explaining the string theory',
+  public: false,
+  panoramic: false,
+  mp4Support: true,
+  tags: [
+    'maths',
+    'string theory',
+    'video',
+  ],
+  metadata: [
+    {
+      key: 'Author',
+      value: 'John Doe',
+    },
+    {
+      key: 'Format',
+      value: 'Tutorial',
+    },
+  ],
+  publishedAt: '2019-12-16T08:25:51+00:00',
+  updateddAt: '2019-12-16T08:48:49+00:00',
+  source: {
+    uri: '/videos/vi4k0jvEUuaTdRAEjQ4Jfagz/source',
+  },
+  assets: {
+    iframe: '<iframe src=\'//embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfagz?token=831a9bd9-9f50-464c-a369-8e9d914371ae\' width=\'100%\' height=\'100%\' frameborder=\'0\' scrolling=\'no\' allowfullscreen=\'\'></iframe>',
+    player: 'https://embed.api.video/vi4k0jvEUuaTdRAEjQ4Jfagz?token=831a9bd9-9f50-464c-a369-8e9d914371ae',
+    hls: 'https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/hls/manifest.m3u8',
+    thumbnail: 'https://cdn.api.video/stream/831a9bd9-9f50-464c-a369-8e9d914371ae/thumbnail.jpg',
+    mp4: 'https://cdn.api.video/vod/vi4k0jvEUuaTdRAEjQ4Jfagz/token/8fd70443-d9f0-45d2-b01c-12c8cfc707c9/mp4/720/source.mp4',
+  },
+};
+
+module.exports = video;

--- a/test/captions.spec.js
+++ b/test/captions.spec.js
@@ -1,9 +1,21 @@
 const path = require('path');
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const apiVideo = require('../lib');
+const Caption = require('../lib/Model/caption');
+const { ITEMS_TOTAL } = require('./api');
 
 describe('Captions ressource', () => {
   describe('Upload', () => {
+    it('Does not throw', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const source = path.join(__dirname, 'data/en.vtt');
+      const properties = {
+        videoId: 'vix1x1x1x1x1x1x1x1x1x',
+        language: 'en',
+      };
+      await client.captions.upload(source, properties);
+    });
+
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const source = path.join(__dirname, 'data/en.vtt');
@@ -11,7 +23,7 @@ describe('Captions ressource', () => {
         videoId: 'vix1x1x1x1x1x1x1x1x1x',
         language: 'en',
       };
-      client.captions.upload(source, properties);
+      client.captions.upload(source, properties).catch(() => {});
       expect(client.captions.browser.lastRequest).to.deep.property('url', 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/captions/en');
       expect(client.captions.browser.lastRequest).to.deep.property('method', 'POST');
       expect(client.captions.browser.lastRequest).to.deep.property('headers', {});
@@ -20,11 +32,18 @@ describe('Captions ressource', () => {
   });
 
   describe('updateDefault', () => {
+    it('Does not throw', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const videoId = 'vix1x1x1x1x1x1x1x1x1x';
+      const language = 'en';
+      await client.captions.updateDefault(videoId, language, true);
+    });
+
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const videoId = 'vix1x1x1x1x1x1x1x1x1x';
       const language = 'en';
-      client.captions.updateDefault(videoId, language, true);
+      client.captions.updateDefault(videoId, language, true).catch(() => {});
       expect(client.captions.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/captions/en',
         method: 'PATCH',
@@ -38,7 +57,7 @@ describe('Captions ressource', () => {
   describe('get', () => {
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
-      client.captions.get('vix1x1x1x1x1x1x1x1x1x', 'en');
+      client.captions.get('vix1x1x1x1x1x1x1x1x1x', 'en').catch(() => {});
       expect(client.captions.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/captions/en',
         method: 'GET',
@@ -46,12 +65,19 @@ describe('Captions ressource', () => {
         json: true,
       });
     });
+
+    it('Returns a caption', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const caption = await client.captions.get('vix1x1x1x1x1x1x1x1x1x', 'en');
+      expect(caption).to.be.an('object');
+      expect(caption).to.have.keys(new Caption());
+    });
   });
 
   describe('getAll', () => {
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
-      client.captions.getAll('vix1x1x1x1x1x1x1x1x1x');
+      client.captions.getAll('vix1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.captions.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/captions',
         method: 'GET',
@@ -59,12 +85,30 @@ describe('Captions ressource', () => {
         json: true,
       });
     });
+
+    it('Returns an array of captions', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const captions = await client.captions.getAll('vix1x1x1x1x1x1x1x1x1x');
+      expect(captions).to.be.an('array');
+      captions.forEach(caption => expect(caption).to.have.keys(new Caption()));
+    });
+
+    it('Returns all captions', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const captions = await client.captions.getAll('vix1x1x1x1x1x1x1x1x1x');
+      expect(captions).to.have.lengthOf(ITEMS_TOTAL);
+    });
   });
 
   describe('delete', () => {
-    it('Sends good request', () => {
+    it('Does not throw', async () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       client.captions.delete('vix1x1x1x1x1x1x1x1x1x', 'en');
+    });
+
+    it('Sends good request', () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      client.captions.delete('vix1x1x1x1x1x1x1x1x1x', 'en').catch(() => {});
       expect(client.captions.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/captions/en',
         method: 'DELETE',
@@ -87,5 +131,4 @@ describe('Captions ressource', () => {
       expect(caption).to.deep.equal(data);
     });
   });
-
 });

--- a/test/chapters.spec.js
+++ b/test/chapters.spec.js
@@ -1,9 +1,21 @@
 const path = require('path');
-const expect = require('chai').expect;
+const { expect } = require('chai');
 const apiVideo = require('../lib');
+const Chapter = require('../lib/Model/chapter');
+const { ITEMS_TOTAL } = require('./api');
 
 describe('Chapters ressource', () => {
   describe('Upload', () => {
+    it('Does not throw', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const source = path.join(__dirname, 'data/en.vtt');
+      const properties = {
+        videoId: 'vix1x1x1x1x1x1x1x1x1x',
+        language: 'en',
+      };
+      await client.chapters.upload(source, properties).catch(() => {});
+    });
+
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const source = path.join(__dirname, 'data/en.vtt');
@@ -11,7 +23,7 @@ describe('Chapters ressource', () => {
         videoId: 'vix1x1x1x1x1x1x1x1x1x',
         language: 'en',
       };
-      client.chapters.upload(source, properties);
+      client.chapters.upload(source, properties).catch(() => {});
       expect(client.chapters.browser.lastRequest).to.deep.property('url', 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/chapters/en');
       expect(client.chapters.browser.lastRequest).to.deep.property('method', 'POST');
       expect(client.chapters.browser.lastRequest).to.deep.property('headers', {});
@@ -22,7 +34,7 @@ describe('Chapters ressource', () => {
   describe('get', () => {
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
-      client.chapters.get('vix1x1x1x1x1x1x1x1x1x', 'en');
+      client.chapters.get('vix1x1x1x1x1x1x1x1x1x', 'en').catch(() => {});
       expect(client.chapters.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/chapters/en',
         method: 'GET',
@@ -30,12 +42,19 @@ describe('Chapters ressource', () => {
         json: true,
       });
     });
+
+    it('Returns a chapter', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const chapter = await client.chapters.get('vix1x1x1x1x1x1x1x1x1x', 'en');
+      expect(chapter).to.be.an('object');
+      expect(chapter).to.have.keys('language', 'src', 'uri');
+    });
   });
 
   describe('getAll', () => {
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
-      client.chapters.getAll('vix1x1x1x1x1x1x1x1x1x');
+      client.chapters.getAll('vix1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.chapters.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/chapters',
         method: 'GET',
@@ -43,12 +62,30 @@ describe('Chapters ressource', () => {
         json: true,
       });
     });
+
+    it('Returns an array of chapters', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const chapters = await client.chapters.getAll('vix1x1x1x1x1x1x1x1x1x');
+      expect(chapters).to.be.an('array');
+      chapters.forEach(chapter => expect(chapter).to.have.keys(new Chapter()));
+    });
+
+    it('Returns all chapters', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const chapters = await client.chapters.getAll('vix1x1x1x1x1x1x1x1x1x');
+      expect(chapters).to.have.lengthOf(ITEMS_TOTAL); // the default page size is 100
+    });
   });
 
   describe('delete', () => {
+    it('Does not throw', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      await client.chapters.delete('vix1x1x1x1x1x1x1x1x1x', 'en');
+    });
+
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
-      client.chapters.delete('vix1x1x1x1x1x1x1x1x1x', 'en');
+      client.chapters.delete('vix1x1x1x1x1x1x1x1x1x', 'en').catch(() => {});
       expect(client.chapters.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/chapters/en',
         method: 'DELETE',
@@ -70,5 +107,4 @@ describe('Chapters ressource', () => {
       expect(chapter).to.deep.equal(data);
     });
   });
-
 });

--- a/test/lives.spec.js
+++ b/test/lives.spec.js
@@ -1,16 +1,26 @@
 const path = require('path');
 const { expect } = require('chai');
 const apiVideo = require('../lib');
+const { ITEMS_TOTAL } = require('./api');
 
 describe('Lives ressource', () => {
   describe('create', () => {
+    it('Does not throw', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const name = 'Live test';
+      const properties = {
+        record: false,
+      };
+      await client.lives.create(name, properties);
+    });
+
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const name = 'Live test';
       const properties = {
         record: false,
       };
-      client.lives.create(name, properties);
+      client.lives.create(name, properties).catch(() => {});
       expect(client.lives.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/live-streams',
         method: 'POST',
@@ -22,12 +32,20 @@ describe('Lives ressource', () => {
   });
 
   describe('update', () => {
+    it('Does not throw', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const properties = {
+        record: true,
+      };
+      await client.lives.update('lix1x1x1x1x1x1x1x1x1x', properties);
+    });
+
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const properties = {
         record: true,
       };
-      client.lives.update('lix1x1x1x1x1x1x1x1x1x', properties);
+      client.lives.update('lix1x1x1x1x1x1x1x1x1x', properties).catch(() => {});
       expect(client.lives.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/live-streams/lix1x1x1x1x1x1x1x1x1x',
         method: 'PATCH',
@@ -38,7 +56,7 @@ describe('Lives ressource', () => {
     });
   });
 
-  describe('get', () => {
+  describe('get', async () => {
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       client.lives.get('lix1x1x1x1x1x1x1x1x1x');
@@ -49,9 +67,15 @@ describe('Lives ressource', () => {
         json: true,
       });
     });
+
+    it('Returns a live-stream', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const live = await client.lives.get('lix1x1x1x1x1x1x1x1x1x');
+      expect(live).to.have.property('liveStreamId');
+    });
   });
 
-  describe('Search with parameters', () => {
+  describe('Search first page', () => {
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const parameters = {
@@ -65,6 +89,26 @@ describe('Lives ressource', () => {
         headers: {},
         json: true,
       });
+    });
+
+    it('Returns an array', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const parameters = {
+        currentPage: 1,
+        pageSize: 25,
+      };
+      const liveStreams = await client.lives.search(parameters);
+      expect(liveStreams).to.be.an.instanceOf(Array);
+    });
+
+    it('Returns only one page', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const parameters = {
+        currentPage: 1,
+        pageSize: 25,
+      };
+      const liveStreams = await client.lives.search(parameters);
+      expect(liveStreams).to.be.of.length(parameters.pageSize);
     });
   });
 
@@ -80,14 +124,35 @@ describe('Lives ressource', () => {
         json: true,
       });
     });
+
+    it('Returns an array', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const parameters = {};
+      const liveStreams = await client.lives.search(parameters);
+      expect(liveStreams).to.be.an.instanceOf(Array);
+    });
+
+    it('Returns all pages', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const parameters = {};
+      const liveStreams = await client.lives.search(parameters);
+      expect(liveStreams).to.be.of.length(ITEMS_TOTAL); // default pageSize is 100
+    });
   });
 
   describe('Upload thumbnail', () => {
+    it('Does not throw', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      const source = path.join(__dirname, 'data/test.png');
+      const liveId = 'lix1x1x1x1x1x1x1x1x1x';
+      await client.lives.uploadThumbnail(source, liveId);
+    });
+
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const source = path.join(__dirname, 'data/test.png');
       const liveId = 'lix1x1x1x1x1x1x1x1x1x';
-      client.lives.uploadThumbnail(source, liveId);
+      client.lives.uploadThumbnail(source, liveId).catch(() => {});
       expect(client.lives.browser.lastRequest).to.deep.property('url', 'https://ws.api.video/live-streams/lix1x1x1x1x1x1x1x1x1x/thumbnail');
       expect(client.lives.browser.lastRequest).to.deep.property('method', 'POST');
       expect(client.lives.browser.lastRequest).to.deep.property('headers', {});
@@ -96,9 +161,14 @@ describe('Lives ressource', () => {
   });
 
   describe('delete', () => {
+    it('Does not throw', async () => {
+      const client = new apiVideo.Client({ apiKey: 'test' });
+      await client.lives.delete('lix1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
-      client.lives.delete('lix1x1x1x1x1x1x1x1x1x');
+      client.lives.delete('lix1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.lives.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/live-streams/lix1x1x1x1x1x1x1x1x1x',
         method: 'DELETE',

--- a/test/players.spec.js
+++ b/test/players.spec.js
@@ -1,36 +1,41 @@
 const path = require('path');
 const { expect } = require('chai');
 const apiVideo = require('../lib');
+const Player = require('../lib/Model/player');
+const { ITEMS_TOTAL } = require('./api');
 
 describe('Players ressource', () => {
+  const client = new apiVideo.Client({ apiKey: 'test' });
+  const properties = {
+    shapeMargin: 10,
+    shapeRadius: 3,
+    shapeAspect: 'flat',
+    shapeBackgroundTop: 'rgba(50, 50, 50, .7)',
+    shapeBackgroundBottom: 'rgba(50, 50, 50, .8)',
+    text: 'rgba(255, 255, 255, .95)',
+    link: 'rgba(255, 0, 0, .95)',
+    linkHover: 'rgba(255, 255, 255, .75)',
+    linkActive: 'rgba(255, 0, 0, .75)',
+    trackPlayed: 'rgba(255, 255, 255, .95)',
+    trackUnplayed: 'rgba(255, 255, 255, .1)',
+    trackBackground: 'rgba(0, 0, 0, 0)',
+    backgroundTop: 'rgba(72, 4, 45, 1)',
+    backgroundBottom: 'rgba(94, 95, 89, 1)',
+    backgroundText: 'rgba(255, 255, 255, .95)',
+    enableApi: true,
+    enableControls: true,
+    forceAutoplay: false,
+    hideTitle: false,
+    forceLoop: false,
+  };
+
   describe('create', () => {
+    it('Does not throw', async () => {
+      await client.players.create(properties);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const properties = {
-        shapeMargin: 10,
-        shapeRadius: 3,
-        shapeAspect: 'flat',
-        shapeBackgroundTop: 'rgba(50, 50, 50, .7)',
-        shapeBackgroundBottom: 'rgba(50, 50, 50, .8)',
-        text: 'rgba(255, 255, 255, .95)',
-        link: 'rgba(255, 0, 0, .95)',
-        linkHover: 'rgba(255, 255, 255, .75)',
-        linkActive: 'rgba(255, 0, 0, .75)',
-        trackPlayed: 'rgba(255, 255, 255, .95)',
-        trackUnplayed: 'rgba(255, 255, 255, .1)',
-        trackBackground: 'rgba(0, 0, 0, 0)',
-        backgroundTop: 'rgba(72, 4, 45, 1)',
-        backgroundBottom: 'rgba(94, 95, 89, 1)',
-        backgroundText: 'rgba(255, 255, 255, .95)',
-        enableApi: true,
-        enableControls: true,
-        forceAutoplay: false,
-        hideTitle: false,
-        forceLoop: false,
-      };
-      client.players.create(properties).catch((error) => {
-        console.log(error);
-      });
+      client.players.create(properties).catch(() => {});
       expect(client.players.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/players',
         method: 'POST',
@@ -42,33 +47,12 @@ describe('Players ressource', () => {
   });
 
   describe('update', () => {
+    it('Does not throw', async () => {
+      await client.players.update('plx1x1x1x1x1x1x1x1x1x', properties);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const properties = {
-        shapeMargin: 10,
-        shapeRadius: 3,
-        shapeAspect: 'flat',
-        shapeBackgroundTop: 'rgba(50, 50, 50, .7)',
-        shapeBackgroundBottom: 'rgba(50, 50, 50, .8)',
-        text: 'rgba(255, 255, 255, .95)',
-        link: 'rgba(255, 0, 0, .95)',
-        linkHover: 'rgba(255, 255, 255, .75)',
-        linkActive: 'rgba(255, 0, 0, .75)',
-        trackPlayed: 'rgba(255, 255, 255, .95)',
-        trackUnplayed: 'rgba(255, 255, 255, .1)',
-        trackBackground: 'rgba(0, 0, 0, 0)',
-        backgroundTop: 'rgba(72, 4, 45, 1)',
-        backgroundBottom: 'rgba(94, 95, 89, 1)',
-        backgroundText: 'rgba(255, 255, 255, .95)',
-        enableApi: true,
-        enableControls: true,
-        forceAutoplay: false,
-        hideTitle: true,
-        forceLoop: true,
-      };
-      client.players.update('plx1x1x1x1x1x1x1x1x1x', properties).catch((error) => {
-        console.log(error);
-      });
+      client.players.update('plx1x1x1x1x1x1x1x1x1x', properties).catch(() => {});
       expect(client.players.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/players/plx1x1x1x1x1x1x1x1x1x',
         method: 'PATCH',
@@ -81,10 +65,7 @@ describe('Players ressource', () => {
 
   describe('get', () => {
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.players.get('plx1x1x1x1x1x1x1x1x1x').catch((error) => {
-        console.log(error);
-      });
+      client.players.get('plx1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.players.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/players/plx1x1x1x1x1x1x1x1x1x',
         method: 'GET',
@@ -92,18 +73,20 @@ describe('Players ressource', () => {
         json: true,
       });
     });
+
+    it('Returns a player', async () => {
+      const player = await client.players.get('plx1x1x1x1x1x1x1x1x1x');
+      expect(player).to.have.keys(Object.keys(new Player()));
+    });
   });
 
-  describe('Search with parameters', () => {
+  describe('Search first page', () => {
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
       const parameters = {
         currentPage: 1,
         pageSize: 25,
       };
-      client.players.search(parameters).catch((error) => {
-        console.log(error);
-      });
+      client.players.search(parameters).catch(() => {});
       expect(client.players.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/players?currentPage=1&pageSize=25',
         method: 'GET',
@@ -111,15 +94,30 @@ describe('Players ressource', () => {
         json: true,
       });
     });
+
+    it('Returns an array', async () => {
+      const parameters = {
+        currentPage: 1,
+        pageSize: 25,
+      };
+      const players = await client.players.search(parameters);
+      expect(players).to.be.an.instanceOf(Array);
+    });
+
+    it('Retrieves only the first page ', async () => {
+      const parameters = {
+        currentPage: 1,
+        pageSize: 25,
+      };
+      const players = await client.players.search(parameters);
+      expect(players).to.have.lengthOf(parameters.pageSize);
+    });
   });
 
   describe('Search without parameters', () => {
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
       const parameters = {};
-      client.players.search(parameters).catch((error) => {
-        console.log(error);
-      });
+      client.players.search(parameters).catch(() => {});
       expect(client.players.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/players?pageSize=100&currentPage=1',
         method: 'GET',
@@ -127,19 +125,25 @@ describe('Players ressource', () => {
         json: true,
       });
     });
+
+    it('Retrieves all pages ', async () => {
+      const parameters = {};
+      const players = await client.players.search(parameters);
+      expect(players).to.have.lengthOf(ITEMS_TOTAL); // default page size is 100
+    });
   });
 
-  // eslint-disable-next-line no-undef
   describe('Upload logo', () => {
-    // eslint-disable-next-line no-undef
+    const source = path.join(__dirname, 'data/test.png');
+    const playerId = 'plx1x1x1x1x1x1x1x1x1x';
+    const link = 'https://api.video';
+
+    it('Does not throw', async () => {
+      await client.players.uploadLogo(source, playerId, link);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const source = path.join(__dirname, 'data/test.png');
-      const playerId = 'plx1x1x1x1x1x1x1x1x1x';
-      const link = 'https://api.video';
-      client.players.uploadLogo(source, playerId, link).catch((error) => {
-        console.log(error);
-      });
+      client.players.uploadLogo(source, playerId, link).catch(() => {});
       expect(client.players.browser.lastRequest).to.deep.property('url', 'https://ws.api.video/players/plx1x1x1x1x1x1x1x1x1x/logo');
       expect(client.players.browser.lastRequest).to.deep.property('method', 'POST');
       expect(client.players.browser.lastRequest).to.deep.property('headers', {});
@@ -148,11 +152,12 @@ describe('Players ressource', () => {
   });
 
   describe('deleteLogo', () => {
+    it('Does not throw', async () => {
+      await client.players.deleteLogo('plx1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.players.deleteLogo('plx1x1x1x1x1x1x1x1x1x').catch((error) => {
-        console.log(error);
-      });
+      client.players.deleteLogo('plx1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.players.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/players/plx1x1x1x1x1x1x1x1x1x/logo',
         method: 'DELETE',
@@ -163,11 +168,12 @@ describe('Players ressource', () => {
   });
 
   describe('delete', () => {
+    it('Does not throw', async () => {
+      await client.players.delete('plx1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.players.delete('plx1x1x1x1x1x1x1x1x1x').catch((error) => {
-        console.log(error);
-      });
+      client.players.delete('plx1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.players.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/players/plx1x1x1x1x1x1x1x1x1x',
         method: 'DELETE',
@@ -179,7 +185,6 @@ describe('Players ressource', () => {
 
   describe('cast', () => {
     it('Should return player object', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
       const data = {
         playerId: 'plx1x1x1x1x1x1x1x1x1x',
         shapeMargin: 10,

--- a/test/tokens.spec.js
+++ b/test/tokens.spec.js
@@ -3,11 +3,13 @@ const apiVideo = require('../lib');
 
 describe('Tokens ressource', () => {
   describe('generate', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    it('Does not throw', async () => {
+      await client.tokens.generate();
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.tokens.generate().catch((error) => {
-        console.log(error);
-      });
+      client.tokens.generate().catch(() => {});
       expect(client.tokens.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/tokens',
         method: 'POST',

--- a/test/videos.spec.js
+++ b/test/videos.spec.js
@@ -1,21 +1,22 @@
 const path = require('path');
 const { expect } = require('chai');
 const apiVideo = require('../lib');
+const { ITEMS_TOTAL } = require('./api');
 
-// eslint-disable-next-line no-undef
 describe('Videos ressource', () => {
-  // eslint-disable-next-line no-undef
   describe('create', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const title = 'Video test';
+    const properties = {
+      description: 'Video test',
+    };
+
+    it('Does not throw', async () => {
+      await client.videos.create(title, properties);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const title = 'Video test';
-      const properties = {
-        description: 'Video test',
-      };
-      client.videos.create(title, properties).catch((error) => {
-        console.log(error);
-      });
+      client.videos.create(title, properties).catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos',
         method: 'POST',
@@ -26,18 +27,20 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
+
   describe('update', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const properties = {
+      description: 'Video test 2',
+      tag: ['test1', 'test2'],
+    };
+
+    it('Does not throw', async () => {
+      await client.videos.update('vix1x1x1x1x1x1x1x1x1x', properties);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const properties = {
-        description: 'Video test 2',
-        tag: ['test1', 'test2'],
-      };
-      client.videos.update('vix1x1x1x1x1x1x1x1x1x', properties).catch((error) => {
-        console.log(error);
-      });
+      client.videos.update('vix1x1x1x1x1x1x1x1x1x', properties).catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x',
         method: 'PATCH',
@@ -48,14 +51,16 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
   describe('get', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      await client.videos
+        .get('vix1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.videos.get('vix1x1x1x1x1x1x1x1x1x').catch((error) => {
-        console.log(error);
-      });
+      client.videos.get('vix1x1x1x1x1x1x1x1x1x');
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x',
         method: 'GET',
@@ -63,16 +68,22 @@ describe('Videos ressource', () => {
         json: true,
       });
     });
+
+    it('Returns a video', async () => {
+      const video = await client.videos.get('vix1x1x1x1x1x1x1x1x1x');
+      expect(video).to.have.property('videoId');
+    });
   });
 
-  // eslint-disable-next-line no-undef
   describe('getStatus', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      await client.videos.getStatus('vix1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.videos.getStatus('vix1x1x1x1x1x1x1x1x1x').catch((error) => {
-        console.log(error);
-      });
+      client.videos.getStatus('vix1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/status',
         method: 'GET',
@@ -82,18 +93,15 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
-  describe('Search with parameters', () => {
-    // eslint-disable-next-line no-undef
+  describe('Search with parameters (currentPage, pageSize)', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {
+      currentPage: 1,
+      pageSize: 25,
+    };
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {
-        currentPage: 1,
-        pageSize: 25,
-      };
-      client.videos.search(parameters).catch((error) => {
-        console.log(error);
-      });
+      client.videos.search(parameters).catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos?currentPage=1&pageSize=25',
         method: 'GET',
@@ -101,17 +109,20 @@ describe('Videos ressource', () => {
         json: true,
       });
     });
+
+    it('Retrieves only specified page ', async () => {
+      const videos = await client.videos.search(parameters);
+      expect(videos).to.be.an.instanceOf(Array);
+      expect(videos).to.have.lengthOf(parameters.pageSize);
+    });
   });
 
-  // eslint-disable-next-line no-undef
   describe('Search without parameters', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const parameters = {};
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const parameters = {};
-      client.videos.search(parameters).catch((error) => {
-        console.log(error);
-      });
+      client.videos.search(parameters);
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos?pageSize=100&currentPage=1',
         method: 'GET',
@@ -119,21 +130,28 @@ describe('Videos ressource', () => {
         json: true,
       });
     });
+
+    it('Retrieves all pages ', async () => {
+      const videos = await client.videos.search(parameters);
+      expect(videos).to.be.an.instanceOf(Array);
+      expect(videos).to.have.lengthOf(ITEMS_TOTAL);
+    });
   });
 
-  // eslint-disable-next-line no-undef
   describe('Download', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const source = 'https://www.example.com/video.mp4';
+    const title = 'Video test';
+    const properties = {
+      description: 'Video test',
+    };
+
+    it('Does not throw', async () => {
+      await client.videos.download(source, title, properties);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const source = 'https://www.example.com/video.mp4';
-      const title = 'Video test';
-      const properties = {
-        description: 'Video test',
-      };
-      client.videos.download(source, title, properties).catch((error) => {
-        console.log(error);
-      });
+      client.videos.download(source, title, properties).catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos',
         method: 'POST',
@@ -144,16 +162,17 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
   describe('Upload', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const source = path.join(__dirname, 'data/small.webm');
+    const videoId = 'vix1x1x1x1x1x1x1x1x1x';
+
+    it('Does not throw', async () => {
+      await client.videos.upload(source, {}, videoId);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const source = path.join(__dirname, 'data/small.webm');
-      const videoId = 'vix1x1x1x1x1x1x1x1x1x';
-      client.videos.upload(source, {}, videoId).catch((error) => {
-        console.log(error);
-      });
+      client.videos.upload(source, {}, videoId).catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.property('url', 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/source');
       expect(client.videos.browser.lastRequest).to.deep.property('method', 'POST');
       expect(client.videos.browser.lastRequest).to.deep.property('headers', {});
@@ -161,16 +180,17 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
   describe('Upload thumbnail', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const source = path.join(__dirname, 'data/test.png');
+    const videoId = 'vix1x1x1x1x1x1x1x1x1x';
+
+    it('Does not throw', async () => {
+      await client.videos.uploadThumbnail(source, videoId);
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const source = path.join(__dirname, 'data/test.png');
-      const videoId = 'vix1x1x1x1x1x1x1x1x1x';
-      client.videos.uploadThumbnail(source, videoId).catch((error) => {
-        console.log(error);
-      });
+      client.videos.uploadThumbnail(source, videoId).catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.property('url', 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/thumbnail');
       expect(client.videos.browser.lastRequest).to.deep.property('method', 'POST');
       expect(client.videos.browser.lastRequest).to.deep.property('headers', {});
@@ -178,17 +198,18 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
   describe('makePublic', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const properties = {
+      public: true,
+    };
+
+    it('Does not throw', async () => {
+      await client.videos.makePublic('vix1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const properties = {
-        public: true,
-      };
-      client.videos.makePublic('vix1x1x1x1x1x1x1x1x1x').catch((error) => {
-        console.log(error);
-      });
+      client.videos.makePublic('vix1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x',
         method: 'PATCH',
@@ -199,17 +220,18 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
   describe('makePrivate', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      await client.videos.makePrivate('vix1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
       const properties = {
         public: false,
       };
-      client.videos.makePrivate('vix1x1x1x1x1x1x1x1x1x').catch((error) => {
-        console.log(error);
-      });
+      client.videos.makePrivate('vix1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x',
         method: 'PATCH',
@@ -220,17 +242,18 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
   describe('updateThumbnailWithTimecode', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    const properties = {
+      timecode: '00:10:05.02',
+    };
+
+    it('Does not throw', async () => {
+      await client.videos.updateThumbnailWithTimecode('vix1x1x1x1x1x1x1x1x1x', '00:10:05.02');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      const properties = {
-        timecode: '00:10:05.02',
-      };
-      client.videos.updateThumbnailWithTimecode('vix1x1x1x1x1x1x1x1x1x', '00:10:05.02').catch((error) => {
-        console.log(error);
-      });
+      client.videos.updateThumbnailWithTimecode('vix1x1x1x1x1x1x1x1x1x', '00:10:05.02').catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x/thumbnail',
         method: 'PATCH',
@@ -241,14 +264,16 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
+
   describe('delete', () => {
-    // eslint-disable-next-line no-undef
+    const client = new apiVideo.Client({ apiKey: 'test' });
+
+    it('Does not throw', async () => {
+      await client.videos.delete('vix1x1x1x1x1x1x1x1x1x');
+    });
+
     it('Sends good request', () => {
-      const client = new apiVideo.Client({ apiKey: 'test' });
-      client.videos.delete('vix1x1x1x1x1x1x1x1x1x').catch((error) => {
-        console.log(error);
-      });
+      client.videos.delete('vix1x1x1x1x1x1x1x1x1x').catch(() => {});
       expect(client.videos.browser.lastRequest).to.deep.equal({
         url: 'https://ws.api.video/videos/vix1x1x1x1x1x1x1x1x1x',
         method: 'DELETE',
@@ -258,9 +283,8 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
+
   describe('cast', () => {
-    // eslint-disable-next-line no-undef
     it('Should return video object', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const data = {
@@ -289,9 +313,7 @@ describe('Videos ressource', () => {
     });
   });
 
-  // eslint-disable-next-line no-undef
   describe('castStatus', () => {
-    // eslint-disable-next-line no-undef
     it('Should return videoStatus object', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const data = {


### PR DESCRIPTION
I adapted my strategy and I'd like propose  the following addition to the test suite **before** merging anything else :
- The `apivideo` API has been mocked using  `nock` (at least all tested resources) see `./tests/api/index.js`.
- Many expectations were added to highlight the current limitations (these expectations would come very handy for the fixes 
 and refactoring to come)

Overall I think it would be best if you could scan the newly added expectations to see if anything is out of the ordinary, but extra care should be taken on the following :

## analyticsVideo

### get 
I assumed that `client.analyticsVideo.get('vix1x1x1x1x1x1x1x1x1x');` shall returns all `AnalyticData` of the video `vix1x1x1x1x1x1x1x1x1x`.
However the current definition is `get(videoId, period = null)` and should be moved to something closer to the remote API capabilities : `get(videoId, parameters)` where parameters could be any of the following arguments combination :
```
{
    currentPage: 1,
    pageSize: 25,
    period: '2020-07'
    metadata: [] // this is currently not implemented in this SDK and will be discussed later
};
```
> This will offer a better and consistent experience regarding other methods

Which leads to the second point.

### search
At the moment  search is implicitly described as being able to search through all analytics of all the video.
But, if no `videoId` is specified, the API endpoint answer with an empty response no matter what `[]`.

Suppose we were to implements this feature on the API side, what would be the expected response ?
```
GET: https://ws.api.video/analytics/videos?period=2020-07
Response: [SessionA, SessionB, ...]
```
It could be a list of sessions, but then we won't be able to attach these sessions to anything since we don't have any reference to the `video`.

OR maybe the SDK `search` method definition could suggest something like that:
```
[
  {
     videoId: 'vix1x1x1x1x1x1x1x1x1x',
     period: '2020-07',
     data:  [SessionA, SessionB, ...]
  },
  {
     videoId: 'vix1x1x1x1x1x1x1x1x1x',
     period: '2020-07',
     data:  [SessionA, SessionB, ...]
  },
  ...
]
```
> I'm not sure it brings any value. This method doesn't work anyway, so I'm just making assumption here.

## analyticsLive

> Exactly the same problem apply to live analytics

## Conclusion

Which leads to the following 2 suggestions : 

1. Either we implement the search purely on the SDK side (since the API method doesn't work) and we just return a list of sessions, meaning: 
    1. Fetch ALL videos.
    2. For each videos fetch ALL pages of sessions matching the given parameters.
    3. Merge all sessions.
> Yeah, that could lead to a pretty inefficient query, but could useful?

2. Just `deprecate` this feature entirely in favor of the `get` method, and implements this on the API side in the future.

Which one would that be?