### PR TITLE
Read chunks directly from source

### DIFF
--- a/lib/Api/videos.js
+++ b/lib/Api/videos.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
+const util = require('util');
 const path = require('path');
-const os = require('os');
-const tempname = require('tempnam');
 const querystring = require('querystring');
 const Video = require('../Model/video');
 const VideoStatus = require('../Model/videoStatus');
@@ -146,50 +145,32 @@ const Videos = function Videos(browser) {
       }));
     }
 
-    const readableStream = fs.createReadStream(source, {
-      highWaterMark: this.chunkSize,
-    });
-
-    const chunks = [];
-    readableStream.on('readable', async () => {
-      const chunkPath = tempname.tempnamSync(os.tmpdir(), 'upload-chunk-');
-      let chunk;
-      while ((chunk = readableStream.read(that.chunkSize)) !== null) {
-        fs.writeFileSync(chunkPath, chunk, {});
-        chunks.push(chunkPath);
-      }
-    });
-
-    let copiedBytes = 0;
-    // eslint-disable-next-line no-unused-vars
     return new Promise((async (resolve, reject) => {
-      let lastResponse = null;
-      await readableStream.on('end', () => {
-        Object.keys(chunks)
-          .forEach(async (key) => {
-            const chunk = chunks[key];
-            const chunkFile = fs.readFileSync(chunk);
-            const from = copiedBytes;
-            copiedBytes += chunkFile.length;
-            lastResponse = await that.browser.submit(
-              `/videos/${slug}/source`,
-              chunk,
-              {
-                'Content-Range': `bytes ${from}-${copiedBytes - 1}/${length}`,
-              },
-            )
-              .catch((error) => {
-                throw new Error(error.message);
-              });
-            fs.unlinkSync(chunk);
-            if (that.browser.isSuccessfull(lastResponse)) {
-              if (lastResponse.headers.lastchunkextension) {
-                const video = that.cast(lastResponse.body);
-                resolve(video);
-              }
-            }
-          });
-      });
+      const file = fs.openSync(source, 'r');
+      const read = util.promisify(fs.read);
+      const buf = Buffer.alloc(that.chunkSize);
+      let lastResponse;
+      for (let offset = 0; offset < length; offset += that.chunkSize) {
+        await read(file, buf, 0, that.chunkSize, offset);
+        console.log(`Uploading ${offset}-${offset + that.chunkSize}...`);
+        lastResponse = await that.browser.submit(
+          `/videos/${slug}/source`,
+          buf,
+          {
+            'Content-Range': `bytes ${offset}-${offset + that.chunkSize}/${length}`,
+          },
+        ).catch((error) => {
+          fs.closeSync(file);
+          throw new Error(error.message);
+        });
+      }
+      if (that.browser.isSuccessfull(lastResponse)) {
+        if (lastResponse.headers.lastchunkextension) {
+          const video = that.cast(lastResponse.body);
+          fs.closeSync(file);
+          resolve(video);
+        }
+      }
     }));
   };
 

--- a/lib/Browser/browser.js
+++ b/lib/Browser/browser.js
@@ -169,7 +169,7 @@ Browser.prototype.submit = async function submit(path, source, headers = {}) {
     method: 'POST',
     headers: Object.assign(this.headers, headers),
     formData: {
-      file: fs.createReadStream(source),
+      file: Buffer.isBuffer(source) ? source : fs.createReadStream(source),
     },
     json: true,
   };


### PR DESCRIPTION
Implements amendment proposed in #23.

- Chunks are now read from disk using fs.read() in an asynchronous for loop.
- browser.submit() modified to accept a buffer in place of a filename.