### PR TITLE
Add deprecation warnings and remove mentions of dead methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 All changes to this project will be documented in this file.
 
+## [1.8.8] - 2021-02-04
+- Deprecate methods using endpoints unavailable in the current API:
+  - `analyticsLive.search`
+  - `analytics.search`
+- Deprecate `accounts.get`
+
 ## [1.8.7] - 2021-01-18
 - Add missing analyticData.session.metadata for live videos
 - Fix upload of large video files

--- a/README.md
+++ b/README.md
@@ -216,35 +216,11 @@ result.then(function(analyticVideo) {
   console.log(analyticVideo.data);
 });
 
-// Search Video Analytics Data for January 2019 and return the first 100 results
-let result = client.analyticsVideo.search({currentPage: 1, pageSize: 100, period: '2019-01'});
-
-result.then(function(analyticsVideo) {
-  for (let x = 0; x < analyticsVideo.length; x += 1) {
-    if (Object.prototype.hasOwnProperty.call(analyticsVideo, x)) {
-      let analyticVideo = analyticsVideo[x];
-      console.log(analyticVideo.data);
-    }
-  }
-});
-
 // Get live Analytics Data for the month of July 2018
 let result = client.analyticsLive.get('liXxxxXxxxXxxxxxxxXX', '2019-01');
 
 result.then(function(analyticLive) {
   console.log(analyticLive.data);
-});
-
-// Search Live Analytics Data between May 2018 and July 2018 and return the first 100 results
-let result = client.analyticsLive.search({currentPage: 1, pageSize: 100, period: '2019-01'});
-
-result.then(function(analyticsLive) {
-  for (let x = 0; x < analyticsLive.length; x += 1) {
-    if (Object.prototype.hasOwnProperty.call(analyticsLive, x)) {
-      let analyticLive = analyticsLive[x];
-      console.log(analyticLive.data);
-    }
-  }
 });
 
 // Get Analytics Session Events for a sessionId
@@ -562,7 +538,6 @@ client.analyticsLive.get(sessionId, parameters);
 |    **get**                          |   **-**               |    **-**                   |   **-**                |      **-**             |
 |    **-**                            |   videoId(string)     |    Video identifier        |   :heavy_check_mark:   |      **-**             |
 |    **-**                            |   period (string)     |    Period research         |   :x:                  |      <ul><li>For a day : 2018-01-01</li><li>For a week: 2018-W01</li><li>For a month: 2018-01</li><li>For a year: 2018</li><li>Date range: 2018-01-01/2018-01-15</li><li>Week range: 2018-W01/2018-W03</li><li>Month range: 2018-01/2018-03</li><li>Year range: 2018/2020</li></ul>             |
-|    **search**                       |   parameters(object)   |    Search parameters       |   :x:                  |      <ul><li>Pagination/Filters:</li><li>currentPage(int)</li><li>pageSize(int)</li><li>sortBy(string)</li><li>sortOrder(string)</li><li>tags(string&#124;array(string))</li><li>metadata(array(string))</li><li>Period:</li><li>For a day : 2018-01-01</li><li>For a week: 2018-W01</li><li>For a month: 2018-01</li><li>For a year: 2018</li><li>Date range: 2018-01-01/2018-01-15</li><li>Week range: 2018-W01/2018-W03</li><li>Month range: 2018-01/2018-03</li><li>Year range: 2018/2020</li></ul>             |
 
 ### AnalyticsLive                         
                                       
@@ -571,7 +546,6 @@ client.analyticsLive.get(sessionId, parameters);
 |    **get**                          |   **-**               |    **-**                   |   **-**                |      **-**             |
 |    **-**                            |   liveStreamId(string)     |    Live identifier        |   :heavy_check_mark:   |      **-**             |
 |    **-**                            |   period (string)     |    Period research         |   :x:                  |      <ul><li>For a day : 2018-01-01</li><li>For a week: 2018-W01</li><li>For a month: 2018-01</li><li>For a year: 2018</li><li>Date range: 2018-01-01/2018-01-15</li><li>Week range: 2018-W01/2018-W03</li><li>Month range: 2018-01/2018-03</li><li>Year range: 2018/2020</li></ul>             |
-|    **search**                       |   parameters(object)   |    Search parameters       |   :x:                  |      <ul><li>Pagination/Filters:</li><li>currentPage(int)</li><li>pageSize(int)</li><li>sortBy(string)</li><li>sortOrder(string)</li><li>Period:</li><li>For a day : 2018-01-01</li><li>For a week: 2018-W01</li><li>For a month: 2018-01</li><li>For a year: 2018</li><li>Date range: 2018-01-01/2018-01-15</li><li>Week range: 2018-W01/2018-W03</li><li>Month range: 2018-01/2018-03</li><li>Year range: 2018/2020</li></ul>             |
                                                      
 ### AnalyticsSessionEvent                         
                                       
@@ -591,7 +565,7 @@ client.analyticsLive.get(sessionId, parameters);
                                       
 |     **Function**                    |   **Parameters**      |      **Description**       |      **Required**      |   **Allowed Values**   |         
 | :---------------------------------: | :-------------------: | :------------------------: | :--------------------: | :--------------------- |
-|    **get**                     |   **-**               | Get account informations (quota, features) |   **-**                |      **-**             |
+|    ~~**get**~~                     |   **-**               | ~~Get account informations (quota, features)~~ |   **-**                |      **-**             |
 ## More on api.video
 
 A full technical documentation is available on https://docs.api.video/

--- a/lib/Api/accounts.js
+++ b/lib/Api/accounts.js
@@ -4,6 +4,9 @@ const Quota = require('../Model/quota');
 const Accounts = function Accounts(browser) {
   this.browser = browser;
 
+  /**
+   * @deprecated
+   */
   this.get = async function get() {
     const that = this;
     const response = await this.browser.get(

--- a/lib/Api/analyticsLive.js
+++ b/lib/Api/analyticsLive.js
@@ -39,6 +39,7 @@ const AnalyticsLive = function AnalyticsLive(browser) {
         analyticVideo.period = parameters.period;
         analyticVideo.data = allAnalytics.reduce(
           (analytics, analyticsPage) => analytics.concat(analyticsPage),
+          [],
         );
 
         resolve(analyticVideo);
@@ -48,51 +49,13 @@ const AnalyticsLive = function AnalyticsLive(browser) {
     }));
   };
 
+  /**
+   * @deprecated searching all analytics isn't possible in current API version
+   */
   this.search = async function search(parameters = {}) {
-    const that = this;
-    const params = parameters;
-    const currentPage = (typeof parameters.currentPage !== 'undefined')
-      ? parameters.currentPage
-      : 1;
-    params.pageSize = (typeof parameters.pageSize !== 'undefined')
-      ? parameters.pageSize
-      : 100;
-
-    params.currentPage = currentPage;
-
-    const allAnalyticsData = [];
-    let pagination = {};
-
-    /* eslint-disable no-await-in-loop */
-    do {
-      const response = await this.browser.get(
-        `/analytics/live-streams?${querystring.stringify(parameters)}`,
-      );
-
-      if (that.browser.isSuccessfull(response)) {
-        const results = response.body;
-        const analyticsData = results.data;
-        allAnalyticsData.push(that.castAll(analyticsData));
-
-        if (typeof parameters.currentPage !== 'undefined') {
-          break;
-        }
-
-        ({ pagination } = results);
-        pagination.currentPage += 1;
-        params.currentPage = pagination.currentPage;
-      }
-    } while (pagination.pagesTotal > pagination.currentPage);
-
-    return new Promise((async (resolve, reject) => {
-      try {
-        resolve(allAnalyticsData.reduce(
-          (analyticsData, analyticsDataPage) => analyticsData.concat(analyticsDataPage),
-        ));
-      } catch (e) {
-        reject(e);
-      }
-    }));
+    const params = Object.assign({ pageSize: 100, currentPage: 1 }, parameters);
+    await this.browser.get(`/analytics/live-streams?${querystring.stringify(params)}`);
+    return new Promise(resolve => resolve([]));
   };
 };
 

--- a/lib/Api/analyticsVideo.js
+++ b/lib/Api/analyticsVideo.js
@@ -38,7 +38,7 @@ const AnalyticsVideo = function AnalyticsVideo(browser) {
         analyticVideo.videoId = videoId;
         analyticVideo.period = parameters.period;
         analyticVideo.data = allAnalytics.reduce(
-          (analytics, analyticsPage) => analytics.concat(analyticsPage),
+          (analytics, analyticsPage) => analytics.concat(analyticsPage), [],
         );
 
         resolve(analyticVideo);
@@ -48,49 +48,13 @@ const AnalyticsVideo = function AnalyticsVideo(browser) {
     }));
   };
 
+  /**
+   * @deprecated searching all analytics isn't possible in current API version
+   */
   this.search = async function search(parameters = {}) {
-    const that = this;
-    const params = Object.assign({}, parameters);
-    const currentPage = (typeof parameters.currentPage !== 'undefined')
-      ? parameters.currentPage
-      : 1;
-    params.pageSize = (typeof parameters.pageSize !== 'undefined')
-      ? parameters.pageSize
-      : 100;
-
-    params.currentPage = currentPage;
-
-    const allAnalytics = [];
-    let pagination = {};
-
-    /* eslint-disable no-await-in-loop */
-    do {
-      const response = await this.browser.get(
-        `/analytics/videos?${querystring.stringify(params)}`,
-      );
-
-      if (this.browser.isSuccessfull(response)) {
-        const results = response.body;
-        const analytics = results.data;
-        allAnalytics.push(that.castAll(analytics));
-
-        if (typeof parameters.currentPage !== 'undefined') {
-          break;
-        }
-
-        ({ pagination } = results);
-        pagination.currentPage += 1;
-        params.currentPage = pagination.currentPage;
-      }
-    } while (pagination.pagesTotal >= pagination.currentPage);
-
-    return new Promise((async (resolve, reject) => {
-      try {
-        resolve(allAnalytics.reduce((analytics, analyticsPage) => analytics.concat(analyticsPage)));
-      } catch (e) {
-        reject(e);
-      }
-    }));
+    const params = Object.assign({ pageSize: 100, currentPage: 1 }, parameters);
+    await this.browser.get(`/analytics/videos?${querystring.stringify(params)}`);
+    return new Promise(resolve => resolve([]));
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.video/nodejs-sdk",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Nodejs SDK for api.video",
   "main": "lib/index.js",
   "repository": {

--- a/test/analyticsLives.spec.js
+++ b/test/analyticsLives.spec.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const { expect, assert } = require('chai');
 const apiVideo = require('../lib');
 const AnalyticLive = require('../lib/Model/Analytic/analyticLive.js');
 const AnalyticData = require('../lib/Model/Analytic/analyticData.js');
@@ -87,14 +87,16 @@ describe('analyticsLive ressource', () => {
       pageSize: 25,
     };
 
-    it('Does not throw', async () => {
-      await client.analyticsLive.search(parameters);
+    it('Throws', async () => {
+      await client.analyticsLive.search(parameters)
+        .then(() => assert.fail())
+        .catch(() => assert(true));
     });
 
     it('Sends good request', () => {
       client.analyticsLive.search(parameters).catch(() => {});
       expect(client.analyticsLive.browser.lastRequest).to.deep.equal({
-        url: 'https://ws.api.video/analytics/live-streams?currentPage=1&pageSize=25',
+        url: 'https://ws.api.video/analytics/live-streams?pageSize=25&currentPage=1',
         method: 'GET',
         headers: {
           'User-Agent': `api.video SDK (nodejs; v:${version})`,
@@ -112,15 +114,16 @@ describe('analyticsLive ressource', () => {
       period: '2019-01',
     };
 
-    it('Does not throw', async () => {
-      await client.analyticsLive
-        .search(parameters);
+    it('Throws', async () => {
+      await client.analyticsLive.search(parameters)
+        .then(() => assert.fail())
+        .catch(() => assert(true));
     });
 
     it('Sends good request', () => {
       client.analyticsLive.search(parameters).catch(() => {});
       expect(client.analyticsLive.browser.lastRequest).to.deep.equal({
-        url: 'https://ws.api.video/analytics/live-streams?currentPage=1&pageSize=25&period=2019-01',
+        url: 'https://ws.api.video/analytics/live-streams?pageSize=25&currentPage=1&period=2019-01',
         method: 'GET',
         headers: {
           'User-Agent': `api.video SDK (nodejs; v:${version})`,
@@ -134,9 +137,10 @@ describe('analyticsLive ressource', () => {
     const client = new apiVideo.Client({ apiKey: 'test' });
     const parameters = {};
 
-    it('Does not throw', async () => {
-      await client.analyticsLive
-        .search(parameters);
+    it('Throws', async () => {
+      await client.analyticsLive.search(parameters)
+        .then(() => assert.fail())
+        .catch(() => assert(true));
     });
 
     it('Sends good request', () => {
@@ -158,15 +162,16 @@ describe('analyticsLive ressource', () => {
       period: '2019-01',
     };
 
-    it('Does not throw', async () => {
-      await client.analyticsLive
-        .search(parameters);
+    it('Throws', async () => {
+      await client.analyticsLive.search(parameters)
+        .then(() => assert.fail())
+        .catch(() => assert(true));
     });
 
     it('Sends good request', () => {
       client.analyticsLive.search(parameters).catch(() => {});
       expect(client.analyticsLive.browser.lastRequest).to.deep.equal({
-        url: 'https://ws.api.video/analytics/live-streams?period=2019-01&pageSize=100&currentPage=1',
+        url: 'https://ws.api.video/analytics/live-streams?pageSize=100&currentPage=1&period=2019-01',
         method: 'GET',
         headers: {
           'User-Agent': `api.video SDK (nodejs; v:${version})`,

--- a/test/analyticsVideos.spec.js
+++ b/test/analyticsVideos.spec.js
@@ -1,4 +1,4 @@
-const { expect } = require('chai');
+const { expect, assert } = require('chai');
 const apiVideo = require('../lib');
 const AnalyticVideo = require('../lib/Model/Analytic/analyticVideo');
 const AnalyticData = require('../lib/Model/Analytic/analyticData');
@@ -84,15 +84,17 @@ describe('AnalyticsVideo ressource', () => {
       pageSize: 25,
     };
 
-    it('Does not throw', async () => {
+    it('Throws', async () => {
       await client.analyticsVideo
-        .search(parameters);
+        .search(parameters)
+        .then(() => assert.fail())
+        .catch(() => assert(true));
     });
 
     it('Sends good request', () => {
       client.analyticsVideo.search(parameters).catch(() => {});
       expect(client.analyticsVideo.browser.lastRequest).to.deep.equal({
-        url: 'https://ws.api.video/analytics/videos?currentPage=1&pageSize=25',
+        url: 'https://ws.api.video/analytics/videos?pageSize=25&currentPage=1',
         method: 'GET',
         headers: {
           'User-Agent': `api.video SDK (nodejs; v:${version})`,
@@ -110,15 +112,17 @@ describe('AnalyticsVideo ressource', () => {
       period: '2019-01',
     };
 
-    it('Does not throw', async () => {
+    it('Throws', async () => {
       await client.analyticsVideo
-        .search(parameters);
+        .search(parameters)
+        .then(() => assert.fail())
+        .catch(() => assert(true));
     });
 
     it('Sends good request', () => {
       client.analyticsVideo.search(parameters).catch(() => {});
       expect(client.analyticsVideo.browser.lastRequest).to.deep.equal({
-        url: 'https://ws.api.video/analytics/videos?currentPage=1&pageSize=25&period=2019-01',
+        url: 'https://ws.api.video/analytics/videos?pageSize=25&currentPage=1&period=2019-01',
         method: 'GET',
         headers: {
           'User-Agent': `api.video SDK (nodejs; v:${version})`,
@@ -132,9 +136,11 @@ describe('AnalyticsVideo ressource', () => {
     const client = new apiVideo.Client({ apiKey: 'test' });
     const parameters = {};
 
-    it('Does not throw', async () => {
+    it('Throws', async () => {
       await client.analyticsVideo
-        .search(parameters);
+        .search(parameters)
+        .then(() => assert.fail())
+        .catch(() => assert(true));
     });
 
     it('Sends good request', () => {
@@ -156,14 +162,17 @@ describe('AnalyticsVideo ressource', () => {
       period: '2019-01',
     };
 
-    it('Does not throw', async () => {
-      await client.analyticsVideo.search(parameters);
+    it('Throw', async () => {
+      await client.analyticsVideo
+        .search(parameters)
+        .then(() => assert.fail())
+        .catch(() => assert(true));
     });
 
     it('Sends good request', () => {
       client.analyticsVideo.search(parameters).catch(() => {});
       expect(client.analyticsVideo.browser.lastRequest).to.deep.equal({
-        url: 'https://ws.api.video/analytics/videos?period=2019-01&pageSize=100&currentPage=1',
+        url: 'https://ws.api.video/analytics/videos?pageSize=100&currentPage=1&period=2019-01',
         method: 'GET',
         headers: {
           'User-Agent': `api.video SDK (nodejs; v:${version})`,

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -33,6 +33,13 @@ const createCollectionReply = (item, itemsTotal = ITEMS_TOTAL) => function () {
   ));
 };
 
+const notFoundResponse = {
+  status: 404,
+  type: 'https://docs.api.video/docs/resourcenot_found',
+  title: 'The requested resource could not be found.',
+  name: '',
+};
+
 exports.mochaHooks = {
   beforeEach(done) {
     nock(BASE)
@@ -112,7 +119,7 @@ exports.mochaHooks = {
       .reply(200, createCollectionReply(analyticData))
       .get('/analytics/videos')
       .query(true)
-      .reply(200, createCollectionReply(analyticData))
+      .replyWithError(notFoundResponse)
 
       // sessions
       .get('/analytics/sessions/psx1x1x1x1x1x1x1x1x1x/events')
@@ -149,7 +156,7 @@ exports.mochaHooks = {
       .reply(200, createCollectionReply(analyticData))
       .get('/analytics/live-streams')
       .query(true)
-      .reply(200, createCollectionReply(analyticData))
+      .replyWithError(notFoundResponse)
 
       // players
       .get('/players')


### PR DESCRIPTION
Before moving on with #35 I just wanted to handle this matter on a separate branch.

It was previously discussed in #14 but the `search` methods of the analytics don't work anymore.
The associated endpoints just don't exist anymore.

I left the methods definitions in there just in case people were, somehow, using it and thus not breaking backward compatibility just yet.
The implementation left of those methods just produce the same weird result as before but is just less verbose.