### PR TITLE
Allow optional `ttl` parameter in `client.tokens.generate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 All changes to this project will be documented in this file.
 
+## [1.10.0] - 2021-02-09
+- Allow optional `ttl` parameter in `client.tokens.generate`
+
 ## [1.9.8] - 2021-02-09
 - Replace `request` library with `got`
   - Fix issues related to the `lastRequest` paradigm (#6, #16)

--- a/lib/Api/tokens.js
+++ b/lib/Api/tokens.js
@@ -1,8 +1,8 @@
 const Tokens = function Tokens(browser) {
   this.browser = browser;
 
-  this.generate = function generate() {
-    return this.browser.post('tokens').then(this.cast);
+  this.generate = function generate(ttl = 0) {
+    return this.browser.post('upload-tokens', {}, { ttl }).then(this.cast);
   };
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@api.video/nodejs-sdk",
-  "version": "1.9.8",
+  "version": "1.10.0",
   "description": "Nodejs SDK for api.video",
   "main": "lib/index.js",
   "repository": {

--- a/test/api/index.js
+++ b/test/api/index.js
@@ -54,7 +54,7 @@ exports.mochaHooks = {
         refresh_token: '',
       })
       // tokens
-      .post('/tokens')
+      .post('/upload-tokens')
       .reply(201)
 
       // unauthorized

--- a/test/tokens.spec.js
+++ b/test/tokens.spec.js
@@ -2,15 +2,22 @@ const { expect } = require('chai');
 const apiVideo = require('../lib');
 
 describe('Tokens ressource', () => {
-  describe('generate', () => {
+  describe('generate without specifying a ttl', () => {
     const client = new apiVideo.Client({ apiKey: 'test' });
     it('Does not throw', async () => {
       await client.tokens.generate();
     });
   });
 
+  describe('generate with a custom ttl', () => {
+    const client = new apiVideo.Client({ apiKey: 'test' });
+    it('Does not throw', async () => {
+      await client.tokens.generate(30);
+    });
+  });
+
   describe('cast', () => {
-    it('Should return caption object', () => {
+    it('Should return a token', () => {
       const client = new apiVideo.Client({ apiKey: 'test' });
       const data = { token: 'tox1x1x1x1x1x1x1x1x1x' };
       const token = client.tokens.cast(data);


### PR DESCRIPTION
fix #33